### PR TITLE
fix type errors with ceil and clamp

### DIFF
--- a/libspy/gcode.py
+++ b/libspy/gcode.py
@@ -1,5 +1,5 @@
 from libspy.node import Layer, Curve
-
+from math import ceil
 
 def isExtrusionCmd(words):
     if words[0] == "G1" and words[1][0] == "X":
@@ -75,7 +75,8 @@ class Gcode:
             curves = self.layers[i].getCurves()
             for j in range(0, len(path), 2):
                 node = path[j]
-                curve = curves[node / 2]
+                node_id = max(0, min(int(ceil(node/2)), len(curves)-1))  # ceil and clamp
+                curve = curves[node_id]
                 if node % 2 == 0:  # write this gcode in original order
                     for l in range(curve.get_startline(), curve.get_endline() + 1):
                         if isExtrusionCmd(self.lines[l].split()):

--- a/libspy/node.py
+++ b/libspy/node.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from math import sqrt
+from math import sqrt, ceil
 from concorde import Tsp
 
 
@@ -91,6 +91,7 @@ class Layer:
                 mincost, best_path = d2, [1, 0]
 
         curve, end = (best_path[-1] / 2), (best_path[-1] % 2)  # start point of last node on path for this layer
+        curve = max(0, min(int(ceil(curve)), len(self.curvelist)-1))  # ceil and clamp
         endpoint = (self.curvelist[curve].get_x(end), self.curvelist[curve].get_y(end))
 
         return mincost, best_path, endpoint


### PR DESCRIPTION
## Changes
- fixed type errors caused by the difference in Python version, as in Python **2.7** `/` operator does integer division, while not in Python **3**
  - an alternative would be using `//` and doing integer division


###### SYSTEM INFO
> Ubuntu 17.1
> GNU Make 4.1
> gcc (Ubuntu 7.2.0-8ubuntu3.2) 7.2.0
> [Concorde-03.12.19](http://www.math.uwaterloo.ca/tsp/concorde/downloads/codes/src/co031219.tgz) @[math.uwaterloo.ca](http://www.math.uwaterloo.ca/tsp/concorde/downloads/downloads.htm)
> [QSopt](http://www.math.uwaterloo.ca/~bico/qsopt/beta/index.html) _Red Hat Linux, gcc 4.4.7, -fPIC (Intel 64-bit)_ @[math.uwaterloo.ca](http://www.math.uwaterloo.ca/~bico/qsopt/beta/index.html)
> edited header: [concorde.h](https://drive.google.com/open?id=1MNWcccmLbYQgLdQ3dL13k19dwjsOfjKj)